### PR TITLE
Fix ClassNotFoundException for ObjectMapperConfigurer

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -65,17 +65,15 @@ Configuration
     mongodb.credentials="user:pass"
     # Configure the servers
     mongodb.servers=host1.example.com:27017,host2.example.com,host3.example.com:19999
-    # Configure a custom ObjectMapper to use
-    mongodb.objectMapperConfigurer=foo.bar.MyObjectMapperConfigurer
 
 The database name defaults to play.  The servers defaults to localhost.  Specifying a port number is optional, it defaults to the default MongoDB port.  If you specify one server, MongoDB will be used as a single server, if you specify multiple, it will be used as a replica set.
 
 Configuring the object mapper
 -----------------------------
 
-If you specify an object mapper configurer, it must be a class with a noarg constructor that implements the trait ``ObjectMapperConfigurer``.  This trait has two methods, one for configuring the global object mapper that will be used for all collections, and another for configuring object mappers per collection.  An example implementation might look like this:
+If you need to adjust Jackson's object mapper, you need to provide a class as a play-plugin that implements the trait ``ObjectMapperConfigurer``. This trait has two methods, one for configuring the global object mapper that will be used for all collections, and another for configuring object mappers per collection.  An example implementation might look like this:
 
-    class MyObjectMapperConfigurer extends ObjectMapperConfigurer {
+    class MyObjectMapperConfigurer(app: Application) extends Plugin with ObjectMapperConfigurer {
         def configure(defaultMapper: ObjectMapper) =
             defaultMapper.configure(DeserializationConfig.Feature.FAIL_ON_UNKNOWN_PROPERTIES, false)
 
@@ -89,6 +87,11 @@ If you specify an object mapper configurer, it must be a class with a noarg cons
             return globalMapper
         }
     }
+	
+To activate the configurer you need to add it to your ``conf/play.plugins`` file. An example might look like this:
+
+	1001:foo.bar.MyObjectMapperConfigurer
+	
 
 Documentation
 -------------

--- a/src/main/scala/play/modules/mongojack/MongoDB.scala
+++ b/src/main/scala/play/modules/mongojack/MongoDB.scala
@@ -168,9 +168,10 @@ class MongoDBPlugin(val app: Application) extends Plugin {
   private lazy val (mongo, db, globalMapper, configurer) = {
 
     // Look up the object mapper configurer
-    val configurer = app.configuration.getString("mongodb.objectMapperConfigurer") map {
-      Class.forName(_).asSubclass(classOf[ObjectMapperConfigurer]).newInstance
-    }
+    val configurer = app.plugin[ObjectMapperConfigurer]
+//    val configurer = app.configuration.getString("mongodb.objectMapperConfigurer") map {
+//      Class.forName(_).asSubclass(classOf[ObjectMapperConfigurer]).newInstance
+//    }
 
     // Configure the default object mapper
     val defaultMapper = MongoJacksonMapperModule.configure(new ObjectMapper).registerModule(new DefaultScalaModule)


### PR DESCRIPTION
At first many thanks for your great work regarding mongojack and this Play plugin. It is a real time saver.

Unfortunately the current mechanism for providing an `ObjectMapperConfigurer` doesn's seem to work properly. I added one to enable (de)serialization of joda-time objects and it worked well when using a `FakeApplication` in my integration tests. But as soon as I ran the application using `play run` it crashed with a ClassNotFoundException when `MongoDB` tried to instantiate my `ObjectMapperConfigurer`.

After trying around a bit, I've got the feeling, that the class loader of the play-mongojack plugin isn't able to access classes from the application. Unfortunately I haven't found a proof for this assumption. 

This pull request replaces the class loading with a plugin based approach (my `ObjectMapperConfigurer` needs to implement play's `Plugin` trait and needs to be added to the project's `play.plugins` file). It is only a one liner and for me it works like a charme. Also see the updated `README.markdown` in the pull request.
